### PR TITLE
Changes: Include strings.h where bzero came from

### DIFF
--- a/src/document.cc
+++ b/src/document.cc
@@ -7,6 +7,7 @@
 #include <cairo.h>
 #include <cairo-svg.h>
 #include <unistd.h>
+#include <strings.h> // bzero
 #include "document.h"
 #include "page.h"
 


### PR DESCRIPTION
Fix for:

 CXX(target) Release/obj.target/pdfutils/src/document.o
../src/document.cc: In member function ‘v8::Handlev8::Value Document::getProperty(const char_)’:
../src/document.cc:248:31: error: ‘bzero’ was not declared in this scope
make: *_\* [Release/obj.target/pdfutils/src/document.o] Error 1
