### PR TITLE
page: implement textAttributes property

### DIFF
--- a/src/page.h
+++ b/src/page.h
@@ -22,6 +22,7 @@ class Page : public node::ObjectWrap {
 		v8::Persistent<v8::Array> links;
 
 		static v8::Handle<v8::Value> GetLinks(v8::Local<v8::String> property, const v8::AccessorInfo &info);
+		static v8::Handle<v8::Value> GetTextAttributes(v8::Local<v8::String> property, const v8::AccessorInfo &info);
 
 		static v8::Handle<v8::Value> ConvertTo(const v8::Arguments& args);
 


### PR DESCRIPTION
Implements a `textAttributes` property on the `Page` object, which retrieves text information that can be used in combination with the `asText` method.
